### PR TITLE
user: Fix teams not set properly for user resource

### DIFF
--- a/pagerduty/resource_pagerduty_team_membership_test.go
+++ b/pagerduty/resource_pagerduty_team_membership_test.go
@@ -81,6 +81,7 @@ func testAccCheckPagerDutyTeamMembershipConfig(user, team string) string {
 resource "pagerduty_user" "foo" {
   name = "%[1]v"
   email = "%[1]v@foo.com"
+  teams = ["${pagerduty_team.foo.id}"]
 }
 
 resource "pagerduty_team" "foo" {

--- a/pagerduty/resource_pagerduty_user.go
+++ b/pagerduty/resource_pagerduty_user.go
@@ -1,6 +1,7 @@
 package pagerduty
 
 import (
+	"fmt"
 	"log"
 
 	"github.com/hashicorp/terraform/helper/schema"
@@ -160,7 +161,11 @@ func resourcePagerDutyUserRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("avatar_url", user.AvatarURL)
 	d.Set("description", user.Description)
 	d.Set("job_title", user.JobTitle)
-	d.Set("teams", user.Teams)
+
+	if err := d.Set("teams", flattenTeams(user.Teams)); err != nil {
+		return fmt.Errorf("error setting teams: %s", err)
+	}
+
 	d.Set("invitation_sent", user.InvitationSent)
 
 	return nil


### PR DESCRIPTION
Fix issue where teams is not properly imported into the state.

### Acceptance test
```
TF_ACC=1 go test -run TestAccPagerDutyUser_Basic ./pagerduty -v -timeout 120m
=== RUN   TestAccPagerDutyUser_Basic
--- PASS: TestAccPagerDutyUser_Basic (18.44s)
PASS
ok      github.com/terraform-providers/terraform-provider-pagerduty/pagerduty   18.468s
```

### Step to reproduce the issue:
#### Using terraform

Example HCL
```
resource "pagerduty_user" "foo" {
  name = "Foo"
  email = "foo@foo.com"
  teams = ["${pagerduty_team.foo.id}"]
}

resource "pagerduty_team" "foo" {
  name        = "Foo"
  description = "foo"
}
```

1. Setup user and team in Pagerduty based on the configuration from the HCL above.
2. Import the terraform HCL above with `terraform import`
3. Doing a `terraform plan` now shows a difference where the team information was not imported