### PR TITLE
user: Fix acceptance tests by updating user role list

### DIFF
--- a/pagerduty/resource_pagerduty_user.go
+++ b/pagerduty/resource_pagerduty_user.go
@@ -43,7 +43,7 @@ func resourcePagerDutyUser() *schema.Resource {
 					"limited_user",
 					"owner",
 					"read_only_user",
-					"team_responder",
+					"observer",
 					"user",
 				}),
 			},

--- a/pagerduty/resource_pagerduty_user_test.go
+++ b/pagerduty/resource_pagerduty_user_test.go
@@ -92,7 +92,7 @@ func TestAccPagerDutyUser_Basic(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"pagerduty_user.foo", "color", "red"),
 					resource.TestCheckResourceAttr(
-						"pagerduty_user.foo", "role", "team_responder"),
+						"pagerduty_user.foo", "role", "observer"),
 					resource.TestCheckResourceAttr(
 						"pagerduty_user.foo", "job_title", "bar"),
 					resource.TestCheckResourceAttr(
@@ -213,7 +213,7 @@ resource "pagerduty_user" "foo" {
   name        = "%s"
   email       = "%s"
   color       = "red"
-  role        = "team_responder"
+  role        = "observer"
   job_title   = "bar"
   description = "bar"
   time_zone   = "Europe/Dublin"


### PR DESCRIPTION
According to the [latest API documentation](https://api-reference.pagerduty.com/#!/Users/get_users), user roles can be one of the following values:

`admin, limited_user, observer, owner, read_only_user, restricted_access or user`

The `team_responder` role is not in the list anymore and instead there is an `observer` role. This makes the acceptance tests fail and this PR fixes that.

### Acceptance tests
```
TF_ACC=1 go test -run TestAccPagerDutyTeamMembership_Basic ./pagerduty -v -timeout 120m
=== RUN   TestAccPagerDutyTeamMembership_Basic
--- PASS: TestAccPagerDutyTeamMembership_Basic (16.71s)
PASS
ok      github.com/terraform-providers/terraform-provider-pagerduty/pagerduty   16.746s
```