### PR TITLE
Fix the exact matching of vendor name when it contains special chars

### DIFF
--- a/pagerduty/data_source_pagerduty_vendor.go
+++ b/pagerduty/data_source_pagerduty_vendor.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"log"
 	"regexp"
+	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/heimweh/go-pagerduty/pagerduty"
@@ -49,10 +50,8 @@ func dataSourcePagerDutyVendorRead(d *schema.ResourceData, meta interface{}) err
 
 	var found *pagerduty.Vendor
 
-	er := regexp.MustCompile(fmt.Sprintf("^(?i)%s$", searchName))
-
 	for _, vendor := range resp.Vendors {
-		if er.MatchString(vendor.Name) {
+		if strings.EqualFold(vendor.Name, searchName) {
 			found = vendor
 			break
 		}

--- a/pagerduty/data_source_pagerduty_vendor_test.go
+++ b/pagerduty/data_source_pagerduty_vendor_test.go
@@ -42,6 +42,24 @@ func TestAccDataSourcePagerDutyVendor_ExactMatch(t *testing.T) {
 	})
 }
 
+func TestAccDataSourcePagerDutyVendor_SpecialChars(t *testing.T) {
+	dataSourceName := "data.pagerduty_vendor.foo"
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckPagerDutyScheduleDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourcePagerDutySpecialCharsConfig,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(dataSourceName, "id", "PRYWPH4"),
+					resource.TestCheckResourceAttr(dataSourceName, "name", "Slack to PagerDuty (Legacy)"),
+				),
+			},
+		},
+	})
+}
+
 const testAccDataSourcePagerDutyVendorConfig = `
 data "pagerduty_vendor" "foo" {
   name = "cloudwatch"
@@ -51,5 +69,11 @@ data "pagerduty_vendor" "foo" {
 const testAccDataSourcePagerDutyExactMatchConfig = `
 data "pagerduty_vendor" "foo" {
   name = "sentry"
+}
+`
+
+const testAccDataSourcePagerDutySpecialCharsConfig = `
+data "pagerduty_vendor" "foo" {
+  name = "Slack to PagerDuty (Legacy)"
 }
 `


### PR DESCRIPTION
Because the previous matching method was using regex, when the vendor's
name contain special chars, it will fail to match. This commit change
the regex matching to use `strings.EqualFold` instead.